### PR TITLE
Add LongCombinableArbitrary

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -236,7 +236,7 @@ public interface CombinableArbitrary<T> {
 	 *
 	 * @return a {@link CombinableArbitrary} returns a randomly generated Long
 	 */
-	@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+	@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 	static LongCombinableArbitrary longs() {
 		return LONG_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -46,6 +46,8 @@ public interface CombinableArbitrary<T> {
 		ServiceLoader.load(StringCombinableArbitrary.class);
 	ServiceLoader<ByteCombinableArbitrary> BYTE_COMBINABLE_ARBITRARY_SERVICE_LOADER =
 		ServiceLoader.load(ByteCombinableArbitrary.class);
+	ServiceLoader<LongCombinableArbitrary> LONG_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(LongCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -228,4 +230,14 @@ public interface CombinableArbitrary<T> {
 		return STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}
 
+	/**
+	 * Generates a {@link LongCombinableArbitrary} which returns a randomly generated Long.
+	 * You can customize the generated Long by using {@link LongCombinableArbitrary}.
+	 *
+	 * @return a {@link CombinableArbitrary} returns a randomly generated Long
+	 */
+	@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+	static LongCombinableArbitrary longs() {
+		return LONG_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
 	@Override
 	Long combined();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
@@ -70,8 +70,6 @@ public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
 
 	/**
 	 * Generates a LongCombinableArbitrary which produces only non-zero longs.
-	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints,
-	 * this method will override all previous constraints and generate only non-zero values from the full Long range.
 	 * Useful for avoiding division by zero errors in mathematical operations.
 	 *
 	 * @return the LongCombinableArbitrary producing non-zero longs
@@ -80,10 +78,6 @@ public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
 
 	/**
 	 * Generates a LongCombinableArbitrary which produces only longs that are multiples of the specified divisor.
-	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints like
-	 * {@link #positive()} or {@link #withRange(long, long)}, this method will override all previous constraints
-	 * and generate multiples of the divisor from the full Long range.
-	 * <p><strong>Warning:</strong> If divisor is 0, this will cause an arithmetic exception during generation.
 	 *
 	 * @param divisor the divisor for multiples (must not be 0)
 	 * @return the LongCombinableArbitrary producing multiples of {@code divisor}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
@@ -80,8 +80,8 @@ public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
 
 	/**
 	 * Generates a LongCombinableArbitrary which produces only longs that are multiples of the specified divisor.
-	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints like 
-	 * {@link #positive()} or {@link #withRange(long, long)}, this method will override all previous constraints 
+	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints like
+	 * {@link #positive()} or {@link #withRange(long, long)}, this method will override all previous constraints
 	 * and generate multiples of the divisor from the full Long range.
 	 * <p><strong>Warning:</strong> If divisor is 0, this will cause an arithmetic exception during generation.
 	 *

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
@@ -1,0 +1,96 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
+	@Override
+	Long combined();
+
+	@Override
+	Long rawValue();
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces longs within the specified range.
+	 *
+	 * @param min the minimum value (inclusive)
+	 * @param max the maximum value (inclusive)
+	 * @return the LongCombinableArbitrary producing longs between {@code min} and {@code max}
+	 */
+	LongCombinableArbitrary withRange(long min, long max);
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces only positive longs.
+	 *
+	 * @return the LongCombinableArbitrary producing positive longs
+	 */
+	LongCombinableArbitrary positive();
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces only negative longs.
+	 *
+	 * @return the LongCombinableArbitrary producing negative longs
+	 */
+	LongCombinableArbitrary negative();
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces only even longs.
+	 *
+	 * @return the LongCombinableArbitrary producing even longs
+	 */
+	LongCombinableArbitrary even();
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces only odd longs.
+	 *
+	 * @return the LongCombinableArbitrary producing odd longs
+	 */
+	LongCombinableArbitrary odd();
+
+	@Override
+	default LongCombinableArbitrary filter(Predicate<Long> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default LongCombinableArbitrary filter(int tries, Predicate<Long> predicate) {
+		return new LongCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	@Override
+	default LongCombinableArbitrary injectNull(double nullProbability) {
+		return new LongCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default LongCombinableArbitrary unique() {
+		return new LongCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitrary.java
@@ -68,6 +68,29 @@ public interface LongCombinableArbitrary extends CombinableArbitrary<Long> {
 	 */
 	LongCombinableArbitrary odd();
 
+	/**
+	 * Generates a LongCombinableArbitrary which produces only non-zero longs.
+	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints,
+	 * this method will override all previous constraints and generate only non-zero values from the full Long range.
+	 * Useful for avoiding division by zero errors in mathematical operations.
+	 *
+	 * @return the LongCombinableArbitrary producing non-zero longs
+	 */
+	LongCombinableArbitrary nonZero();
+
+	/**
+	 * Generates a LongCombinableArbitrary which produces only longs that are multiples of the specified divisor.
+	 * <p><strong>Note:</strong> Following the last-method-wins principle, when combined with other constraints like 
+	 * {@link #positive()} or {@link #withRange(long, long)}, this method will override all previous constraints 
+	 * and generate multiples of the divisor from the full Long range.
+	 * <p><strong>Warning:</strong> If divisor is 0, this will cause an arithmetic exception during generation.
+	 *
+	 * @param divisor the divisor for multiples (must not be 0)
+	 * @return the LongCombinableArbitrary producing multiples of {@code divisor}
+	 * @throws ArithmeticException if divisor is 0
+	 */
+	LongCombinableArbitrary multipleOf(long divisor);
+
 	@Override
 	default LongCombinableArbitrary filter(Predicate<Long> predicate) {
 		return this.filter(DEFAULT_MAX_TRIES, predicate);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
@@ -65,6 +65,16 @@ final class LongCombinableArbitraryDelegator implements LongCombinableArbitrary 
 	}
 
 	@Override
+	public LongCombinableArbitrary nonZero() {
+		return CombinableArbitrary.longs().nonZero();
+	}
+
+	@Override
+	public LongCombinableArbitrary multipleOf(long divisor) {
+		return CombinableArbitrary.longs().multipleOf(divisor);
+	}
+
+	@Override
 	public void clear() {
 		delegate.clear();
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
@@ -1,0 +1,76 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+final class LongCombinableArbitraryDelegator implements LongCombinableArbitrary {
+	private final CombinableArbitrary<Long> delegate;
+
+	public LongCombinableArbitraryDelegator(CombinableArbitrary<Long> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Long combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public Long rawValue() {
+		return delegate.combined();
+	}
+
+	@Override
+	public LongCombinableArbitrary withRange(long min, long max) {
+		return CombinableArbitrary.longs().withRange(min, max);
+	}
+
+	@Override
+	public LongCombinableArbitrary positive() {
+		return CombinableArbitrary.longs().positive();
+	}
+
+	@Override
+	public LongCombinableArbitrary negative() {
+		return CombinableArbitrary.longs().negative();
+	}
+
+	@Override
+	public LongCombinableArbitrary even() {
+		return CombinableArbitrary.longs().even();
+	}
+
+	@Override
+	public LongCombinableArbitrary odd() {
+		return CombinableArbitrary.longs().odd();
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryDelegator.java
@@ -21,7 +21,7 @@ package com.navercorp.fixturemonkey.api.arbitrary;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 final class LongCombinableArbitraryDelegator implements LongCombinableArbitrary {
 	private final CombinableArbitrary<Long> delegate;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -26,7 +26,7 @@ import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary;
 
-@API(since = "1.1.12", status = Status.EXPERIMENTAL)
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
 public final class JqwikLongCombinableArbitrary implements LongCombinableArbitrary {
 	private final Arbitrary<Long> longArbitrary;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -26,7 +26,7 @@ import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 public final class JqwikLongCombinableArbitrary implements LongCombinableArbitrary {
 	private final Arbitrary<Long> longArbitrary;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -67,22 +67,33 @@ public final class JqwikLongCombinableArbitrary implements LongCombinableArbitra
 
 	@Override
 	public LongCombinableArbitrary even() {
-		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % 2 == 0));
+		return new JqwikLongCombinableArbitrary(
+			Arbitraries.longs().map(JqwikLongCombinableArbitrary::toEven)
+		);
 	}
 
 	@Override
 	public LongCombinableArbitrary odd() {
-		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % 2 != 0));
+		return new JqwikLongCombinableArbitrary(
+			Arbitraries.longs().map(JqwikLongCombinableArbitrary::toOdd)
+		);
 	}
 
 	@Override
 	public LongCombinableArbitrary nonZero() {
-		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it != 0));
+		return new JqwikLongCombinableArbitrary(
+			Arbitraries.longs().map(JqwikLongCombinableArbitrary::ensureNonZero)
+		);
 	}
 
 	@Override
 	public LongCombinableArbitrary multipleOf(long divisor) {
-		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % divisor == 0));
+		if (divisor == 0L) {
+			throw new IllegalArgumentException("divisor must not be zero.");
+		}
+		return new JqwikLongCombinableArbitrary(
+			Arbitraries.longs().map(it -> toMultipleOf(it, divisor))
+		);
 	}
 
 	@Override
@@ -93,5 +104,25 @@ public final class JqwikLongCombinableArbitrary implements LongCombinableArbitra
 	@Override
 	public boolean fixed() {
 		return false;
+	}
+
+	private static long toEven(long value) {
+		return value & ~1L;
+	}
+
+	private static long toOdd(long value) {
+		return (value & ~1L) | 1L;
+	}
+
+	private static long ensureNonZero(long value) {
+		return value == 0L ? 1L : value;
+	}
+
+	private static long toMultipleOf(long value, long divisor) {
+		long remainder = value % divisor;
+		if (remainder == 0L) {
+			return value;
+		}
+		return value - remainder;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -76,6 +76,16 @@ public final class JqwikLongCombinableArbitrary implements LongCombinableArbitra
 	}
 
 	@Override
+	public LongCombinableArbitrary nonZero() {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it != 0));
+	}
+
+	@Override
+	public LongCombinableArbitrary multipleOf(long divisor) {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % divisor == 0));
+	}
+
+	@Override
 	public void clear() {
 		// ignored
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -1,0 +1,87 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary;
+
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
+public final class JqwikLongCombinableArbitrary implements LongCombinableArbitrary {
+	private final Arbitrary<Long> longArbitrary;
+
+	public JqwikLongCombinableArbitrary() {
+		this(Arbitraries.longs());
+	}
+
+	private JqwikLongCombinableArbitrary(Arbitrary<Long> longArbitrary) {
+		this.longArbitrary = longArbitrary;
+	}
+
+	@Override
+	public Long combined() {
+		return this.longArbitrary.sample();
+	}
+
+	@Override
+	public Long rawValue() {
+		return this.combined();
+	}
+
+	@Override
+	public LongCombinableArbitrary withRange(long minValue, long maxValue) {
+		return new JqwikLongCombinableArbitrary(
+			Arbitraries.longs().between(minValue, maxValue)
+		);
+	}
+
+	@Override
+	public LongCombinableArbitrary positive() {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().greaterOrEqual(1L));
+	}
+
+	@Override
+	public LongCombinableArbitrary negative() {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().lessOrEqual(-1L));
+	}
+
+	@Override
+	public LongCombinableArbitrary even() {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % 2 == 0));
+	}
+
+	@Override
+	public LongCombinableArbitrary odd() {
+		return new JqwikLongCombinableArbitrary(Arbitraries.longs().filter(it -> it % 2 != 0));
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikLongCombinableArbitrary.java
@@ -88,9 +88,6 @@ public final class JqwikLongCombinableArbitrary implements LongCombinableArbitra
 
 	@Override
 	public LongCombinableArbitrary multipleOf(long divisor) {
-		if (divisor == 0L) {
-			throw new IllegalArgumentException("divisor must not be zero.");
-		}
 		return new JqwikLongCombinableArbitrary(
 			Arbitraries.longs().map(it -> toMultipleOf(it, divisor))
 		);

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikLongCombinableArbitrary

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
@@ -19,13 +19,10 @@
 package com.navercorp.fixturemonkey.api.arbitrary;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
-
-import com.navercorp.fixturemonkey.api.exception.FixedValueFilterMissException;
 
 class LongCombinableArbitraryTest {
 	@Test
@@ -104,26 +101,15 @@ class LongCombinableArbitraryTest {
 	}
 
 	@Test
-	void longUnique() {
-		// filter().unique() => FixedValueFilterMissException
-		thenThrownBy(() -> CombinableArbitrary.longs()
-			.filter(x -> x == 123L)
+	void longUniqueWithDifferentValues() {
+		// when - unique() works with different values
+		Long actual = CombinableArbitrary.longs()
+			.withRange(100L, 200L)  // wide range
 			.unique()
-			.combined())
-			.isExactlyInstanceOf(FixedValueFilterMissException.class);
-	}
-
-	@Test
-	void longMapping() {
-		// when
-		String actual = CombinableArbitrary.longs()
-			.withRange(100L, 200L)
-			.map(x -> "prefix" + x)
 			.combined();
 
 		// then
-		then(actual).startsWith("prefix");
-		then(actual).contains("1");
+		then(actual).isBetween(100L, 200L);
 	}
 
 	@Test
@@ -191,18 +177,6 @@ class LongCombinableArbitraryTest {
 		String numberPart = actual.substring(6);
 		long number = Long.parseLong(numberPart);
 		then(number).isBetween(6L, 10L);
-	}
-
-	@Test
-	void longUniqueWithDifferentValues() {
-		// when
-		Long actual = CombinableArbitrary.longs()
-			.withRange(1L, 1000L)
-			.unique()
-			.combined();
-
-		// then
-		then(actual).isBetween(1L, 1000L);
 	}
 
 	@Test
@@ -301,30 +275,27 @@ class LongCombinableArbitraryTest {
 
 	@Test
 	void nonZeroWithRangeExcludingZero() {
-		// when - range already excludes 0, nonZero() is redundant but harmless
+		// when - nonZero() is applied after withRange(), so it overrides the range constraint
 		Long actual = CombinableArbitrary.longs()
 			.withRange(10L, 20L)
 			.nonZero()
 			.combined();
 
-		// then
+		// then - since nonZero() is last, it only ensures the value is not zero
 		then(actual).isNotEqualTo(0L);
-		then(actual).isBetween(10L, 20L);
 	}
 
 	@Test
 	void multipleOfWithComplexConstraints() {
-		// when - multiple constraints: negative + range + multiple of 4
+		// positive().withRange(1L, 50L).multipleOf(3L) => multipleOf(3L)
 		Long actual = CombinableArbitrary.longs()
-			.negative()
+			.positive()
 			.withRange(-100L, -1L)
-			.multipleOf(4L)
+			.multipleOf(3L)
 			.combined();
 
 		// then
-		then(actual).isNegative();
-		then(actual).isBetween(-100L, -1L);
-		then(actual % 4L).isEqualTo(0L);
+		then(actual % 3L).isEqualTo(0L);
 	}
 
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
@@ -234,4 +234,97 @@ class LongCombinableArbitraryTest {
 		then(allOdd).isTrue();
 	}
 
+	@Test
+	void nonZero() {
+		// when
+		boolean allNonZero = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.longs().nonZero().combined())
+			.allMatch(value -> value != 0);
+
+		// then
+		then(allNonZero).isTrue();
+	}
+
+	@Test
+	void multipleOf() {
+		// when
+		boolean allMultipleOfFive = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.longs().multipleOf(5L).combined())
+			.allMatch(value -> value % 5 == 0);
+
+		// then
+		then(allMultipleOfFive).isTrue();
+	}
+
+	@Test
+	void nonZeroCombined() {
+		// when
+		Long actual = CombinableArbitrary.longs().nonZero().combined();
+
+		// then
+		then(actual).isNotEqualTo(0L);
+	}
+
+	@Test
+	void multipleOfCombined() {
+		// when
+		Long actual = CombinableArbitrary.longs().multipleOf(7L).combined();
+
+		// then
+		then(actual % 7L).isEqualTo(0L);
+	}
+
+	@Test
+	void nonZeroWithRangeCombined() {
+		// withRange(-5L, 5L).nonZero() => nonZero()
+		Long actual = CombinableArbitrary.longs()
+			.withRange(-5L, 5L)
+			.nonZero()
+			.combined();
+
+		// then
+		then(actual).isNotEqualTo(0L);
+	}
+
+	@Test
+	void multipleOfWithPositiveAndRangeCombined() {
+		// positive().withRange(1L, 50L).multipleOf(3L) => multipleOf(3L)
+		Long actual = CombinableArbitrary.longs()
+			.positive()
+			.withRange(1L, 50L)
+			.multipleOf(3L)
+			.combined();
+
+		// then
+		then(actual % 3L).isEqualTo(0L);
+	}
+
+	@Test
+	void nonZeroWithRangeExcludingZero() {
+		// when - range already excludes 0, nonZero() is redundant but harmless
+		Long actual = CombinableArbitrary.longs()
+			.withRange(10L, 20L)
+			.nonZero()
+			.combined();
+
+		// then
+		then(actual).isNotEqualTo(0L);
+		then(actual).isBetween(10L, 20L);
+	}
+
+	@Test
+	void multipleOfWithComplexConstraints() {
+		// when - multiple constraints: negative + range + multiple of 4
+		Long actual = CombinableArbitrary.longs()
+			.negative()
+			.withRange(-100L, -1L)
+			.multipleOf(4L)
+			.combined();
+
+		// then
+		then(actual).isNegative();
+		then(actual).isBetween(-100L, -1L);
+		then(actual % 4L).isEqualTo(0L);
+	}
+
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/LongCombinableArbitraryTest.java
@@ -1,0 +1,237 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.navercorp.fixturemonkey.api.exception.FixedValueFilterMissException;
+
+class LongCombinableArbitraryTest {
+	@Test
+	void combined() {
+		// when
+		Long actual = CombinableArbitrary.longs().combined();
+
+		// then
+		then(actual).isInstanceOf(Long.class);
+	}
+
+	@Test
+	void withRange() {
+		// given
+		long min = 100L;
+		long max = 200L;
+
+		// when
+		Long actual = CombinableArbitrary.longs().withRange(min, max).combined();
+
+		// then
+		then(actual).isBetween(min, max);
+	}
+
+	@Test
+	void positive() {
+		// when
+		Long actual = CombinableArbitrary.longs().positive().combined();
+
+		// then
+		then(actual).isPositive();
+	}
+
+	@Test
+	void negative() {
+		// when
+		Long actual = CombinableArbitrary.longs().negative().combined();
+
+		// then
+		then(actual).isNegative();
+	}
+
+	@Test
+	void even() {
+		// when
+		boolean allEven = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.longs().even().combined())
+			.allMatch(value -> value % 2 == 0);
+
+		// then
+		then(allEven).isTrue();
+	}
+
+	@Test
+	void odd() {
+		// when
+		boolean allOdd = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.longs().odd().combined())
+			.allMatch(value -> value % 2 != 0);
+
+		// then
+		then(allOdd).isTrue();
+	}
+
+	@Test
+	void lastMethodWinsWithPositiveAndRange() {
+		// given
+		long min = 100L;
+		long max = 200L;
+
+		// positive().withRange(min, max) => withRange(min, max)
+		Long actual = CombinableArbitrary.longs().positive().withRange(min, max).combined();
+
+		// then
+		then(actual).isBetween(min, max);
+	}
+
+	@Test
+	void longUnique() {
+		// filter().unique() => FixedValueFilterMissException
+		thenThrownBy(() -> CombinableArbitrary.longs()
+			.filter(x -> x == 123L)
+			.unique()
+			.combined())
+			.isExactlyInstanceOf(FixedValueFilterMissException.class);
+	}
+
+	@Test
+	void longMapping() {
+		// when
+		String actual = CombinableArbitrary.longs()
+			.withRange(100L, 200L)
+			.map(x -> "prefix" + x)
+			.combined();
+
+		// then
+		then(actual).startsWith("prefix");
+		then(actual).contains("1");
+	}
+
+	@Test
+	void longFiltering() {
+		// when
+		Long actual = CombinableArbitrary.longs()
+			.withRange(0L, 1000L)
+			.filter(x -> x > 500L)
+			.combined();
+
+		// then
+		then(actual).isGreaterThan(500L);
+		then(actual).isLessThanOrEqualTo(1000L);
+	}
+
+	@Test
+	void longFilteringWithMultipleConditions() {
+		// when
+		Long actual = CombinableArbitrary.longs()
+			.withRange(0L, 100L)
+			.filter(x -> x % 10 == 0)
+			.combined();
+
+		// then
+		then(actual % 10).isEqualTo(0L);
+		then(actual).isBetween(0L, 100L);
+	}
+
+	@Test
+	void longInjectNull() {
+		// when
+		Long actual = CombinableArbitrary.longs()
+			.withRange(1L, 100L)
+			.injectNull(1.0)
+			.combined();
+
+		// then
+		then(actual).isNull();
+	}
+
+	@Test
+	void longInjectNullWithZeroProbability() {
+		// when
+		Long actual = CombinableArbitrary.longs()
+			.withRange(1L, 100L)
+			.injectNull(0.0)
+			.combined();
+
+		// then
+		then(actual).isNotNull();
+		then(actual).isBetween(1L, 100L);
+	}
+
+	@Test
+	void longCombinationWithMultipleOperations() {
+		// when
+		String actual = CombinableArbitrary.longs()
+			.withRange(1L, 10L)
+			.filter(x -> x > 5L)
+			.map(x -> "value:" + x)
+			.combined();
+
+		// then
+		then(actual).startsWith("value:");
+		String numberPart = actual.substring(6);
+		long number = Long.parseLong(numberPart);
+		then(number).isBetween(6L, 10L);
+	}
+
+	@Test
+	void longUniqueWithDifferentValues() {
+		// when
+		Long actual = CombinableArbitrary.longs()
+			.withRange(1L, 1000L)
+			.unique()
+			.combined();
+
+		// then
+		then(actual).isBetween(1L, 1000L);
+	}
+
+	@Test
+	void fixed() {
+		// when
+		boolean actual = CombinableArbitrary.longs().fixed();
+
+		// then
+		then(actual).isFalse();
+	}
+
+	@Test
+	void lastMethodWinsPositiveOverNegative() {
+		// positive().negative() => negative()
+		boolean allNegative = IntStream.range(0, 30)
+			.mapToObj(i -> CombinableArbitrary.longs().positive().negative().combined())
+			.allMatch(value -> value < 0);
+
+		then(allNegative).isTrue();
+	}
+
+	@Test
+	void lastMethodWinsEvenOverOdd() {
+		// even().odd() => odd()
+		boolean allOdd = IntStream.range(0, 30)
+			.mapToObj(i -> CombinableArbitrary.longs().even().odd().combined())
+			.allMatch(value -> value % 2 != 0);
+
+		then(allOdd).isTrue();
+	}
+
+}

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
@@ -23,6 +23,7 @@ import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet
 import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import io.kotest.property.Arb
@@ -39,7 +40,6 @@ import io.kotest.property.arbitrary.instant
 import io.kotest.property.arbitrary.localDate
 import io.kotest.property.arbitrary.localDateTime
 import io.kotest.property.arbitrary.localTime
-import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.offsetDateTime
 import io.kotest.property.arbitrary.period
@@ -205,18 +205,17 @@ class KotestJavaArbitraryGeneratorSet(
         }
     }
 
-    override fun longs(context: ArbitraryGeneratorContext): CombinableArbitrary<Long> {
+    override fun longs(context: ArbitraryGeneratorContext): LongCombinableArbitrary {
         val integerConstraint = constraintGenerator.generateIntegerConstraint(context)
 
-        return CombinableArbitrary.from {
-            if (integerConstraint != null) {
-                val min = integerConstraint.min?.toLong() ?: Long.MIN_VALUE
-                val max = integerConstraint.max?.toLong() ?: Long.MAX_VALUE
+        val combinableArbitrary = KotestLongCombinableArbitrary()
+        return if (integerConstraint != null) {
+            val min = integerConstraint.min?.toLong() ?: Long.MIN_VALUE
+            val max = integerConstraint.max?.toLong() ?: Long.MAX_VALUE
 
-                Arb.long(min = min, max = max).single()
-            } else {
-                Arb.long().single()
-            }
+            combinableArbitrary.withRange(min, max)
+        } else {
+            combinableArbitrary
         }
     }
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
@@ -22,8 +22,8 @@ import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.long
-import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.arbitrary.negativeLong
+import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.arbitrary.single
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
@@ -47,6 +47,12 @@ class KotestLongCombinableArbitrary(private val arb: Arb<Long> = Arb.long()) : L
 
     override fun odd(): LongCombinableArbitrary =
         KotestLongCombinableArbitrary(Arb.long().filter { it % 2 != 0.toLong() })
+
+    override fun nonZero(): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long().filter { it != 0.toLong() })
+
+    override fun multipleOf(divisor: Long): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long().filter { it % divisor == 0.toLong() })
 
     override fun filter(tries: Int, predicate: Predicate<Long>): LongCombinableArbitrary =
         KotestLongCombinableArbitrary(Arb.long().filter(predicate::test))

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
@@ -22,6 +22,7 @@ import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.negativeLong
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.arbitrary.single
@@ -43,16 +44,16 @@ class KotestLongCombinableArbitrary(private val arb: Arb<Long> = Arb.long()) : L
     override fun negative(): LongCombinableArbitrary = KotestLongCombinableArbitrary(Arb.negativeLong())
 
     override fun even(): LongCombinableArbitrary =
-        KotestLongCombinableArbitrary(Arb.long().filter { it % 2 == 0.toLong() })
+        KotestLongCombinableArbitrary(Arb.long().map(::toEven))
 
     override fun odd(): LongCombinableArbitrary =
-        KotestLongCombinableArbitrary(Arb.long().filter { it % 2 != 0.toLong() })
+        KotestLongCombinableArbitrary(Arb.long().map(::toOdd))
 
     override fun nonZero(): LongCombinableArbitrary =
-        KotestLongCombinableArbitrary(Arb.long().filter { it != 0.toLong() })
+        KotestLongCombinableArbitrary(Arb.long().map(::ensureNonZero))
 
     override fun multipleOf(divisor: Long): LongCombinableArbitrary =
-        KotestLongCombinableArbitrary(Arb.long().filter { it % divisor == 0.toLong() })
+        KotestLongCombinableArbitrary(Arb.long().map { toMultipleOf(it, divisor) })
 
     override fun filter(tries: Int, predicate: Predicate<Long>): LongCombinableArbitrary =
         KotestLongCombinableArbitrary(Arb.long().filter(predicate::test))
@@ -61,4 +62,18 @@ class KotestLongCombinableArbitrary(private val arb: Arb<Long> = Arb.long()) : L
     }
 
     override fun fixed(): Boolean = false
+
+    companion object {
+        private fun toEven(value: Long): Long = value and -2L
+
+        private fun toOdd(value: Long): Long = toEven(value) or 1L
+
+        private fun ensureNonZero(value: Long): Long = if (value == 0L) 1L else value
+
+        private fun toMultipleOf(value: Long, divisor: Long): Long {
+            require(divisor != 0L) { "divisor must not be zero." }
+            val remainder = value % divisor
+            return if (remainder == 0L) value else value - remainder
+        }
+    }
 }

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
@@ -29,7 +29,7 @@ import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
 import java.util.function.Predicate
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 class KotestLongCombinableArbitrary(private val arb: Arb<Long> = Arb.long()) : LongCombinableArbitrary {
     override fun combined(): Long = arb.single()
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestLongCombinableArbitrary.kt
@@ -1,0 +1,58 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.positiveLong
+import io.kotest.property.arbitrary.negativeLong
+import io.kotest.property.arbitrary.single
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status
+import java.util.function.Predicate
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+class KotestLongCombinableArbitrary(private val arb: Arb<Long> = Arb.long()) : LongCombinableArbitrary {
+    override fun combined(): Long = arb.single()
+
+    override fun rawValue(): Long = this.combined()
+
+    override fun withRange(min: Long, max: Long): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long(min..max))
+
+    override fun positive(): LongCombinableArbitrary = KotestLongCombinableArbitrary(Arb.positiveLong())
+
+    override fun negative(): LongCombinableArbitrary = KotestLongCombinableArbitrary(Arb.negativeLong())
+
+    override fun even(): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long().filter { it % 2 == 0.toLong() })
+
+    override fun odd(): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long().filter { it % 2 != 0.toLong() })
+
+    override fun filter(tries: Int, predicate: Predicate<Long>): LongCombinableArbitrary =
+        KotestLongCombinableArbitrary(Arb.long().filter(predicate::test))
+
+    override fun clear() {
+    }
+
+    override fun fixed(): Boolean = false
+}

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.LongCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestLongCombinableArbitrary

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/CombinableArbitraryTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/CombinableArbitraryTest.java
@@ -10,6 +10,7 @@ import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikByteCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikIntegerCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.jqwik.JqwikLongCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikStringCombinableArbitrary;
 
 class CombinableArbitraryTest {
@@ -95,6 +96,90 @@ class CombinableArbitraryTest {
 		Integer actual = CombinableArbitrary.integers().negative().withRange(100, 1000).combined();
 
 		then(actual).isBetween(100, 1000);
+	}
+
+	@Test
+	void longCombinableArbitraryIsJqwik() {
+		CombinableArbitrary<Long> actual = CombinableArbitrary.longs();
+
+		then(actual).isInstanceOf(JqwikLongCombinableArbitrary.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryInjectNull() {
+		Long actual = CombinableArbitrary.longs().injectNull(1).combined();
+
+		then(actual).isNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryFilter() {
+		Long actual = CombinableArbitrary.longs().filter(it -> it > 10000L).combined();
+
+		then(actual).isGreaterThan(10000L);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryPositive() {
+		Long actual = CombinableArbitrary.longs().positive().combined();
+
+		then(actual).isPositive();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryNegative() {
+		Long actual = CombinableArbitrary.longs().negative().combined();
+
+		then(actual).isNegative();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryWithRange() {
+		Long actual = CombinableArbitrary.longs().withRange(10L, 100L).combined();
+
+		then(actual).isBetween(10L, 100L);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryWithRangeAndFilter() {
+		Long actual = CombinableArbitrary.longs().withRange(10L, 100L).filter(it -> 75L <= it).combined();
+
+		then(actual).isBetween(75L, 100L);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryEven() {
+		Long actual = CombinableArbitrary.longs().even().combined();
+
+		then(actual % 2).isEqualTo(0);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryOdd() {
+		Long actual = CombinableArbitrary.longs().odd().combined();
+
+		then(actual % 2 != 0).isTrue();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryLastOperationWinsWithPositiveAndNegative() {
+		Long actual = CombinableArbitrary.longs().positive().negative().combined();
+
+		then(actual).isNegative();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryLastOperationWinsWithEvenAndOdd() {
+		Long actual = CombinableArbitrary.longs().even().odd().combined();
+
+		then(actual % 2 != 0).isTrue();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void longCombinableArbitraryLastOperationWinsWithNegativeAndRange() {
+		Long actual = CombinableArbitrary.longs().negative().withRange(100L, 1000L).combined();
+
+		then(actual).isBetween(100L, 1000L);
 	}
 
 	@Test

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -1003,6 +1003,64 @@ class KotestInJunitTest {
         then(actual).isBetween(10L, 20L)
     }
 
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryNonZero() {
+        val actual = CombinableArbitrary.longs().nonZero().combined()
+
+        then(actual).isNotEqualTo(0L)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryMultipleOf() {
+        val actual = CombinableArbitrary.longs().multipleOf(7L).combined()
+
+        then(actual % 7L).isEqualTo(0L)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryNonZeroWithRange() {
+        // withRange(-5L, 5L).nonZero() => nonZero()
+        val actual = CombinableArbitrary.longs().withRange(-5L, 5L).nonZero().combined()
+
+        then(actual).isNotEqualTo(0L)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryMultipleOfWithPositiveAndRange() {
+        // positive().withRange(1L, 50L).multipleOf(3L) => multipleOf(3L)
+        val actual = CombinableArbitrary.longs()
+            .positive()
+            .withRange(1L, 50L)
+            .multipleOf(3L)
+            .combined()
+
+        then(actual % 3L).isEqualTo(0L)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryLastMethodWinsWithPositiveAndNegative() {
+        // positive().negative() => negative()
+        val actual = CombinableArbitrary.longs().positive().negative().combined()
+
+        then(actual).isNegative()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryLastMethodWinsWithEvenAndOdd() {
+        // even().odd() => odd()
+        val actual = CombinableArbitrary.longs().even().odd().combined()
+
+        then(actual.toInt() % 2 != 0).isTrue()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryLastMethodWinsWithNegativeAndRange() {
+        // negative().withRange() => withRange()
+        val actual = CombinableArbitrary.longs().negative().withRange(100L, 1000L).combined()
+
+        then(actual).isBetween(100L, 1000L)
+    }
+
 
     @Test
     fun stringCombinableArbitrary() {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -22,7 +22,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
 import com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary
-import com.navercorp.fixturemonkey.kotest.KotestByteCombinableArbitrary
+import com.navercorp.fixturemonkey.kotest.KotestLongCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestPlugin
 import com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.giveMeArb
@@ -919,13 +919,6 @@ class KotestInJunitTest {
         then(actual).isBetween(10, 20)
     }
 
-    @Test
-    fun byteCombinableArbitrary() {
-        val actual = CombinableArbitrary.bytes()
-
-        then(actual).isInstanceOf(KotestByteCombinableArbitrary::class.java)
-    }
-
     @RepeatedTest(TEST_COUNT)
     fun byteCombinableArbitraryPositive() {
         val actual = CombinableArbitrary.bytes().positive().combined()
@@ -967,6 +960,49 @@ class KotestInJunitTest {
 
         then(actual).isBetween(10.toByte(), 20.toByte())
     }
+
+    @Test
+    fun longCombinableArbitrary() {
+        val actual = CombinableArbitrary.longs()
+
+        then(actual).isInstanceOf(KotestLongCombinableArbitrary::class.java)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryPositive() {
+        val actual = CombinableArbitrary.longs().positive().combined()
+
+        then(actual).isPositive()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryNegative() {
+        val actual = CombinableArbitrary.longs().negative().combined()
+
+        then(actual).isNegative()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryEven() {
+        val actual = CombinableArbitrary.longs().even().combined()
+
+        then(actual % 2).isEqualTo(0)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryOdd() {
+        val actual = CombinableArbitrary.longs().odd().combined()
+
+        then(actual % 2 != 0.toLong()).isTrue()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun longCombinableArbitraryWithRange() {
+        val actual = CombinableArbitrary.longs().withRange(10L, 20L).combined()
+
+        then(actual).isBetween(10L, 20L)
+    }
+
 
     @Test
     fun stringCombinableArbitrary() {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -22,6 +22,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
 import com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary
+import com.navercorp.fixturemonkey.kotest.KotestByteCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestLongCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestPlugin
 import com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary
@@ -917,6 +918,13 @@ class KotestInJunitTest {
         val actual = CombinableArbitrary.integers().withRange(10, 20).combined()
 
         then(actual).isBetween(10, 20)
+    }
+
+    @Test
+    fun byteCombinableArbitrary() {
+        val actual = CombinableArbitrary.bytes()
+
+        then(actual).isInstanceOf(KotestByteCombinableArbitrary::class.java)
     }
 
     @RepeatedTest(TEST_COUNT)


### PR DESCRIPTION
## Summary
Add LongCombinableArbitrary for customizable Long value generation following existing CombinableArbitrary pattern with Long-specific enhancements.

## Description
Implemented LongCombinableArbitrary to provide easy customization of Long value generation, addressing the lack of long-specific constraints in current API.

**Added components:**
- `LongCombinableArbitrary` interface with standard constraint methods
- `LongCombinableArbitraryDelegator` for filter/null injection operations  
- `JqwikLongCombinableArbitrary` implementation
- Factory method `CombinableArbitrary.longs()`

**Key features:**
- Standard numeric constraints: `.positive()`, `.negative()`, `.even()`, `.odd()`, `.withRange(long, long)`
- Long-specific `.nonZero()` method for avoiding division by zero errors
- Long-specific `.multipleOf(long)` method for generating multiples of specific values
- Last-method-wins behavior for constraint precedence (nonZero/multipleOf override previous constraints)
- Full integration with existing filter/map/unique operations

**Usage example:**
```java
Long nonZeroLong = CombinableArbitrary.longs().nonZero().combined();
Long multipleOfSeven = CombinableArbitrary.longs().multipleOf(7L).combined();
Long positiveLong = CombinableArbitrary.longs().withRange(1L, 1000L).positive().combined();
```

## How Has This Been Tested?
Added comprehensive test suite in `LongCombinableArbitraryTest`:
- Basic constraint validation (positive, negative, even, odd, nonZero, multipleOf)
- Range constraint testing with various boundaries
- Method chaining and last-method-wins precedence verification
- Integration with filter, map, injectNull, unique operations
- Complex constraint combinations and mathematical operation safety

## Is the Document updated?
Documentation will be updated to include LongCombinableArbitrary usage examples alongside existing numeric arbitrary types.