### PR TITLE
Add DoubleCombinableArbitrary

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -236,7 +236,7 @@ public interface CombinableArbitrary<T> {
 	 *
 	 * @return a {@link CombinableArbitrary} returns a randomly generated Double
 	 */
-	@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+	@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 	static DoubleCombinableArbitrary doubles() {
 		return DOUBLE_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -46,6 +46,8 @@ public interface CombinableArbitrary<T> {
 		ServiceLoader.load(StringCombinableArbitrary.class);
 	ServiceLoader<ByteCombinableArbitrary> BYTE_COMBINABLE_ARBITRARY_SERVICE_LOADER =
 		ServiceLoader.load(ByteCombinableArbitrary.class);
+	ServiceLoader<DoubleCombinableArbitrary> DOUBLE_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(DoubleCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -226,6 +228,17 @@ public interface CombinableArbitrary<T> {
 	@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 	static StringCombinableArbitrary strings() {
 		return STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
+
+	/**
+	 * Generates a {@link DoubleCombinableArbitrary} which returns a randomly generated Double.
+	 * You can customize the generated Double by using {@link DoubleCombinableArbitrary}.
+	 *
+	 * @return a {@link CombinableArbitrary} returns a randomly generated Double
+	 */
+	@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+	static DoubleCombinableArbitrary doubles() {
+		return DOUBLE_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}
 
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitrary.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 public interface DoubleCombinableArbitrary extends CombinableArbitrary<Double> {
 	@Override
 	Double combined();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitrary.java
@@ -1,0 +1,158 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+public interface DoubleCombinableArbitrary extends CombinableArbitrary<Double> {
+	@Override
+	Double combined();
+
+	@Override
+	Double rawValue();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces doubles within the specified range.
+	 *
+	 * @param min the minimum value (inclusive)
+	 * @param max the maximum value (inclusive)
+	 * @return the DoubleCombinableArbitrary producing doubles between {@code min} and {@code max}
+	 */
+	DoubleCombinableArbitrary withRange(double min, double max);
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces only positive doubles.
+	 *
+	 * @return the DoubleCombinableArbitrary producing positive doubles
+	 */
+	DoubleCombinableArbitrary positive();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces only negative doubles.
+	 *
+	 * @return the DoubleCombinableArbitrary producing negative doubles
+	 */
+	DoubleCombinableArbitrary negative();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces only non-zero doubles.
+	 * Useful for avoiding division by zero errors in mathematical operations.
+	 *
+	 * @return the DoubleCombinableArbitrary producing non-zero doubles
+	 */
+	DoubleCombinableArbitrary nonZero();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary with specified precision (decimal places).
+	 *
+	 * @param scale the number of decimal places
+	 * @return the DoubleCombinableArbitrary producing doubles with specified precision
+	 */
+	DoubleCombinableArbitrary withPrecision(int scale);
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces only finite doubles.
+	 * Excludes NaN and Infinity values.
+	 *
+	 * @return the DoubleCombinableArbitrary producing finite doubles
+	 */
+	DoubleCombinableArbitrary finite();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces infinite doubles.
+	 *
+	 * @return the DoubleCombinableArbitrary producing infinite doubles
+	 */
+	DoubleCombinableArbitrary infinite();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces normalized doubles (0.0 to 1.0).
+	 *
+	 * @return the DoubleCombinableArbitrary producing normalized doubles
+	 */
+	DoubleCombinableArbitrary normalized();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces NaN values.
+	 *
+	 * @return the DoubleCombinableArbitrary producing NaN doubles
+	 */
+	DoubleCombinableArbitrary nan();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces values 0-100 for percentage representation.
+	 *
+	 * @return the DoubleCombinableArbitrary producing percentage doubles
+	 */
+	DoubleCombinableArbitrary percentage();
+
+	/**
+	 * Generates a DoubleCombinableArbitrary which produces values 0-100 for scoring systems.
+	 *
+	 * @return the DoubleCombinableArbitrary producing score doubles
+	 */
+	DoubleCombinableArbitrary score();
+
+	/**
+	 * Injects a special value into generated values and edge cases.
+	 * This value can be outside the constraints of the arbitrary.
+	 *
+	 * @param special the special value to inject
+	 * @return the DoubleCombinableArbitrary with injected special value
+	 */
+	DoubleCombinableArbitrary withSpecialValue(double special);
+
+	/**
+	 * Injects a selection of standard special values:
+	 * Double.NaN, Double.MIN_VALUE, Double.MIN_NORMAL, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY
+	 *
+	 * @return the DoubleCombinableArbitrary with standard special values
+	 */
+	DoubleCombinableArbitrary withStandardSpecialValues();
+
+	@Override
+	default DoubleCombinableArbitrary filter(Predicate<Double> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default DoubleCombinableArbitrary filter(int tries, Predicate<Double> predicate) {
+		return new DoubleCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	@Override
+	default DoubleCombinableArbitrary injectNull(double nullProbability) {
+		return new DoubleCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default DoubleCombinableArbitrary unique() {
+		return new DoubleCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryDelegator.java
@@ -1,0 +1,116 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+final class DoubleCombinableArbitraryDelegator implements DoubleCombinableArbitrary {
+	private final CombinableArbitrary<Double> delegate;
+
+	public DoubleCombinableArbitraryDelegator(CombinableArbitrary<Double> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Double combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public Double rawValue() {
+		return (Double)delegate.rawValue();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withRange(double min, double max) {
+		return CombinableArbitrary.doubles().withRange(min, max);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary positive() {
+		return CombinableArbitrary.doubles().positive();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary negative() {
+		return CombinableArbitrary.doubles().negative();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary nonZero() {
+		return CombinableArbitrary.doubles().nonZero();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withPrecision(int scale) {
+		return CombinableArbitrary.doubles().withPrecision(scale);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary finite() {
+		return CombinableArbitrary.doubles().finite();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary infinite() {
+		return CombinableArbitrary.doubles().infinite();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary normalized() {
+		return CombinableArbitrary.doubles().normalized();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary nan() {
+		return CombinableArbitrary.doubles().nan();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary percentage() {
+		return CombinableArbitrary.doubles().percentage();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary score() {
+		return CombinableArbitrary.doubles().score();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withSpecialValue(double special) {
+		return CombinableArbitrary.doubles().withSpecialValue(special);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withStandardSpecialValues() {
+		return CombinableArbitrary.doubles().withStandardSpecialValues();
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryDelegator.java
@@ -21,7 +21,7 @@ package com.navercorp.fixturemonkey.api.arbitrary;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 final class DoubleCombinableArbitraryDelegator implements DoubleCombinableArbitrary {
 	private final CombinableArbitrary<Double> delegate;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
@@ -1,0 +1,162 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary;
+
+@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+public final class JqwikDoubleCombinableArbitrary implements DoubleCombinableArbitrary {
+	private final Arbitrary<Double> doubleArbitrary;
+
+	public JqwikDoubleCombinableArbitrary() {
+		this.doubleArbitrary = Arbitraries.doubles();
+	}
+
+	private JqwikDoubleCombinableArbitrary(Arbitrary<Double> doubleArbitrary) {
+		this.doubleArbitrary = doubleArbitrary;
+	}
+
+	@Override
+	public Double rawValue() {
+		return this.doubleArbitrary.sample();
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withRange(double minValue, double maxValue) {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().between(minValue, maxValue)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary positive() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().greaterThan(0.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary negative() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().lessThan(0.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary nonZero() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().filter(d -> d != 0.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withPrecision(int scale) {
+		return new JqwikDoubleCombinableArbitrary(
+			this.doubleArbitrary.map(d -> BigDecimal.valueOf(d)
+				.setScale(scale, RoundingMode.HALF_UP)
+				.doubleValue())
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary finite() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().filter(d -> Double.isFinite(d))
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary infinite() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary normalized() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().between(0.0, 1.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary nan() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.of(Double.NaN)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary percentage() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().between(0.0, 100.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary score() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.doubles().between(0.0, 100.0)
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withSpecialValue(double special) {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.oneOf(this.doubleArbitrary, Arbitraries.of(special))
+		);
+	}
+
+	@Override
+	public DoubleCombinableArbitrary withStandardSpecialValues() {
+		return new JqwikDoubleCombinableArbitrary(
+			Arbitraries.oneOf(
+				this.doubleArbitrary,
+				Arbitraries.of(Double.NaN),
+				Arbitraries.of(Double.MIN_VALUE),
+				Arbitraries.of(Double.POSITIVE_INFINITY),
+				Arbitraries.of(Double.NEGATIVE_INFINITY)
+			)
+		);
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+
+	@Override
+	public Double combined() {
+		return this.doubleArbitrary.sample();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
@@ -137,10 +137,13 @@ public final class JqwikDoubleCombinableArbitrary implements DoubleCombinableArb
 		return new JqwikDoubleCombinableArbitrary(
 			Arbitraries.oneOf(
 				this.doubleArbitrary,
-				Arbitraries.of(Double.NaN),
-				Arbitraries.of(Double.MIN_VALUE),
-				Arbitraries.of(Double.POSITIVE_INFINITY),
-				Arbitraries.of(Double.NEGATIVE_INFINITY)
+				Arbitraries.of(
+					Double.NaN,
+					Double.MIN_VALUE,
+					Double.MIN_NORMAL,
+					Double.POSITIVE_INFINITY,
+					Double.NEGATIVE_INFINITY
+				)
 			)
 		);
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikDoubleCombinableArbitrary.java
@@ -29,7 +29,7 @@ import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary;
 
-@API(since = "1.1.15", status = Status.EXPERIMENTAL)
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 public final class JqwikDoubleCombinableArbitrary implements DoubleCombinableArbitrary {
 	private final Arbitrary<Double> doubleArbitrary;
 

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikDoubleCombinableArbitrary

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryTest.java
@@ -1,0 +1,221 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+class DoubleCombinableArbitraryTest {
+	@Test
+	void combined() {
+		// when
+		Double actual = CombinableArbitrary.doubles().combined();
+
+		// then
+		then(actual).isInstanceOf(Double.class);
+	}
+
+	@Test
+	void withRange() {
+		// given
+		double min = 1.0;
+		double max = 10.0;
+
+		// when
+		Double actual = CombinableArbitrary.doubles().withRange(min, max).combined();
+
+		// then
+		then(actual).isBetween(min, max);
+	}
+
+	@Test
+	void positive() {
+		// when
+		boolean allPositive = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().positive().combined())
+			.allMatch(d -> d > 0.0);
+
+		// then
+		then(allPositive).isTrue();
+	}
+
+	@Test
+	void negative() {
+		// when
+		boolean allNegative = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().negative().combined())
+			.allMatch(d -> d < 0.0);
+
+		// then
+		then(allNegative).isTrue();
+	}
+
+	@Test
+	void nonZero() {
+		// when
+		boolean allNonZero = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().nonZero().combined())
+			.allMatch(d -> d != 0.0);
+
+		// then
+		then(allNonZero).isTrue();
+	}
+
+	@Test
+	void withPrecision() {
+		// given
+		int scale = 2;
+
+		// when
+		Double actual = CombinableArbitrary.doubles().withPrecision(scale).combined();
+
+		// then
+		String actualStr = actual.toString();
+		int decimalIndex = actualStr.indexOf('.');
+		if (decimalIndex != -1) {
+			int actualScale = actualStr.length() - decimalIndex - 1;
+			then(actualScale).isLessThanOrEqualTo(scale);
+		}
+	}
+
+	@Test
+	void finite() {
+		// when
+		boolean allFinite = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().finite().combined())
+			.allMatch(Double::isFinite);
+
+		// then
+		then(allFinite).isTrue();
+	}
+
+	@Test
+	void infinite() {
+		// when
+		Double actual = CombinableArbitrary.doubles().infinite().combined();
+
+		// then
+		then(Double.isInfinite(actual)).isTrue();
+	}
+
+	@Test
+	void normalized() {
+		// when
+		boolean allNormalized = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().normalized().combined())
+			.allMatch(d -> d >= 0.0 && d <= 1.0);
+
+		// then
+		then(allNormalized).isTrue();
+	}
+
+	@Test
+	void nan() {
+		// when
+		Double actual = CombinableArbitrary.doubles().nan().combined();
+
+		// then
+		then(Double.isNaN(actual)).isTrue();
+	}
+
+	@Test
+	void percentage() {
+		// when
+		boolean allPercentage = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().percentage().combined())
+			.allMatch(d -> d >= 0.0 && d <= 100.0);
+
+		// then
+		then(allPercentage).isTrue();
+	}
+
+	@Test
+	void score() {
+		// when
+		boolean allScore = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().score().combined())
+			.allMatch(d -> d >= 0.0 && d <= 100.0);
+
+		// then
+		then(allScore).isTrue();
+	}
+
+	@Test
+	void withSpecialValue() {
+		// given
+		double specialValue = 999.9;
+
+		// when - try multiple times to verify special value injection
+		boolean specialValueFound = IntStream.range(0, 1000)
+			.mapToObj(i -> CombinableArbitrary.doubles().withRange(1.0, 10.0).withSpecialValue(specialValue).combined())
+			.anyMatch(d -> Double.compare(d, specialValue) == 0);
+
+		// then
+		then(specialValueFound).isTrue();
+	}
+
+	@Test
+	void withStandardSpecialValues() {
+		// when - try multiple times to verify standard special values injection
+		boolean hasNaN = IntStream.range(0, 1000)
+			.mapToObj(i -> CombinableArbitrary.doubles().withRange(1.0, 10.0).withStandardSpecialValues().combined())
+			.anyMatch(d -> Double.isNaN(d));
+
+		boolean hasInfinity = IntStream.range(0, 1000)
+			.mapToObj(i -> CombinableArbitrary.doubles().withRange(1.0, 10.0).withStandardSpecialValues().combined())
+			.anyMatch(d -> Double.isInfinite(d));
+
+		// then
+		then(hasNaN || hasInfinity).isTrue(); // at least one special value should be generated
+	}
+
+	@Test
+	void lastMethodWinsPositiveOverNegative() {
+		// when - negative().positive() => positive()
+		boolean allPositive = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().negative().positive().combined())
+			.allMatch(d -> d > 0.0);
+
+		// then
+		then(allPositive).isTrue();
+	}
+
+	@Test
+	void lastMethodWinsRangeOverPositive() {
+		// when - positive().withRange(-10, -1) => withRange(-10, -1)
+		boolean allInRange = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.doubles().positive().withRange(-10.0, -1.0).combined())
+			.allMatch(d -> d >= -10.0 && d <= -1.0);
+
+		// then
+		then(allInRange).isTrue();
+	}
+
+	@Test
+	void fixed() {
+		// when
+		boolean actual = CombinableArbitrary.doubles().fixed();
+
+		// then
+		then(actual).isFalse();
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/DoubleCombinableArbitraryTest.java
@@ -50,34 +50,28 @@ class DoubleCombinableArbitraryTest {
 	@Test
 	void positive() {
 		// when
-		boolean allPositive = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().positive().combined())
-			.allMatch(d -> d > 0.0);
+		Double actual = CombinableArbitrary.doubles().positive().combined();
 
 		// then
-		then(allPositive).isTrue();
+		then(actual).isPositive();
 	}
 
 	@Test
 	void negative() {
 		// when
-		boolean allNegative = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().negative().combined())
-			.allMatch(d -> d < 0.0);
+		Double actual = CombinableArbitrary.doubles().negative().combined();
 
 		// then
-		then(allNegative).isTrue();
+		then(actual).isNegative();
 	}
 
 	@Test
 	void nonZero() {
 		// when
-		boolean allNonZero = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().nonZero().combined())
-			.allMatch(d -> d != 0.0);
+		Double actual = CombinableArbitrary.doubles().nonZero().combined();
 
 		// then
-		then(allNonZero).isTrue();
+		then(actual).isNotEqualTo(0.0);
 	}
 
 	@Test
@@ -100,12 +94,10 @@ class DoubleCombinableArbitraryTest {
 	@Test
 	void finite() {
 		// when
-		boolean allFinite = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().finite().combined())
-			.allMatch(Double::isFinite);
+		Double actual = CombinableArbitrary.doubles().finite().combined();
 
 		// then
-		then(allFinite).isTrue();
+		then(Double.isFinite(actual)).isTrue();
 	}
 
 	@Test
@@ -120,12 +112,10 @@ class DoubleCombinableArbitraryTest {
 	@Test
 	void normalized() {
 		// when
-		boolean allNormalized = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().normalized().combined())
-			.allMatch(d -> d >= 0.0 && d <= 1.0);
+		Double actual = CombinableArbitrary.doubles().normalized().combined();
 
 		// then
-		then(allNormalized).isTrue();
+		then(actual).isBetween(0.0, 1.0);
 	}
 
 	@Test
@@ -140,23 +130,19 @@ class DoubleCombinableArbitraryTest {
 	@Test
 	void percentage() {
 		// when
-		boolean allPercentage = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().percentage().combined())
-			.allMatch(d -> d >= 0.0 && d <= 100.0);
+		Double actual = CombinableArbitrary.doubles().percentage().combined();
 
 		// then
-		then(allPercentage).isTrue();
+		then(actual).isBetween(0.0, 100.0);
 	}
 
 	@Test
 	void score() {
 		// when
-		boolean allScore = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().score().combined())
-			.allMatch(d -> d >= 0.0 && d <= 100.0);
+		Double actual = CombinableArbitrary.doubles().score().combined();
 
 		// then
-		then(allScore).isTrue();
+		then(actual).isBetween(0.0, 100.0);
 	}
 
 	@Test
@@ -191,23 +177,19 @@ class DoubleCombinableArbitraryTest {
 	@Test
 	void lastMethodWinsPositiveOverNegative() {
 		// when - negative().positive() => positive()
-		boolean allPositive = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().negative().positive().combined())
-			.allMatch(d -> d > 0.0);
+		Double actual = CombinableArbitrary.doubles().negative().positive().combined();
 
 		// then
-		then(allPositive).isTrue();
+		then(actual).isPositive();
 	}
 
 	@Test
 	void lastMethodWinsRangeOverPositive() {
 		// when - positive().withRange(-10, -1) => withRange(-10, -1)
-		boolean allInRange = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.doubles().positive().withRange(-10.0, -1.0).combined())
-			.allMatch(d -> d >= -10.0 && d <= -1.0);
+		Double actual = CombinableArbitrary.doubles().positive().withRange(-10.0, -1.0).combined();
 
 		// then
-		then(allInRange).isTrue();
+		then(actual).isBetween(-10.0, -1.0);
 	}
 
 	@Test

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
@@ -114,8 +114,6 @@ class KotestDoubleCombinableArbitrary(
         )
     }
 
-
-
     override fun clear() {
         // No-op for Kotest
     }

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
@@ -26,9 +26,12 @@ import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.single
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status
 import java.math.BigDecimal
 import java.math.RoundingMode
 
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
 class KotestDoubleCombinableArbitrary(
     private val doubleArb: Arb<Double> = Arb.double()
 ) : DoubleCombinableArbitrary {

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestDoubleCombinableArbitrary.kt
@@ -1,0 +1,124 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.double
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.constant
+import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.single
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class KotestDoubleCombinableArbitrary(
+    private val doubleArb: Arb<Double> = Arb.double()
+) : DoubleCombinableArbitrary {
+
+    override fun combined(): Double = doubleArb.single()
+
+    override fun rawValue(): Double = doubleArb.single()
+
+    override fun withRange(min: Double, max: Double): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(min, max))
+    }
+
+    override fun positive(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(Double.MIN_VALUE, Double.MAX_VALUE))
+    }
+
+    override fun negative(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(-Double.MAX_VALUE, -Double.MIN_VALUE))
+    }
+
+    override fun nonZero(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(doubleArb.filter { it != 0.0 })
+    }
+
+    override fun withPrecision(scale: Int): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(
+            doubleArb.map { value ->
+                BigDecimal.valueOf(value)
+                    .setScale(scale, RoundingMode.HALF_UP)
+                    .toDouble()
+            }
+        )
+    }
+
+    override fun finite(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(doubleArb.filter { it.isFinite() })
+    }
+
+    override fun infinite(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(
+            Arb.choice(
+                Arb.constant(Double.POSITIVE_INFINITY),
+                Arb.constant(Double.NEGATIVE_INFINITY)
+            )
+        )
+    }
+
+    override fun normalized(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(0.0, 1.0))
+    }
+
+    override fun nan(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.constant(Double.NaN))
+    }
+
+    override fun percentage(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(0.0, 100.0))
+    }
+
+    override fun score(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(Arb.double(0.0, 100.0))
+    }
+
+    override fun withSpecialValue(special: Double): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(
+            Arb.choice(
+                doubleArb,
+                Arb.constant(special)
+            )
+        )
+    }
+
+    override fun withStandardSpecialValues(): DoubleCombinableArbitrary {
+        return KotestDoubleCombinableArbitrary(
+            Arb.choice(
+                doubleArb,
+                Arb.constant(Double.NaN),
+                Arb.constant(Double.MIN_VALUE),
+                Arb.constant(Double.MIN_VALUE), // MIN_NORMAL doesn't exist in Kotlin
+                Arb.constant(Double.POSITIVE_INFINITY),
+                Arb.constant(Double.NEGATIVE_INFINITY)
+            )
+        )
+    }
+
+
+
+    override fun clear() {
+        // No-op for Kotest
+    }
+
+    override fun fixed(): Boolean = false
+}

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.DoubleCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestDoubleCombinableArbitrary


### PR DESCRIPTION
## Summary
Add DoubleCombinableArbitrary for customizable Double value generation following existing CombinableArbitrary pattern with Double-specific enhancements including precision control and special value handling.

## Description
Implemented DoubleCombinableArbitrary to provide easy customization of Double value generation, addressing the lack of double-specific constraints in current API with enhanced domain-specific methods and comprehensive special value support.

**Added components:**
- `DoubleCombinableArbitrary` interface with standard constraint methods and domain-specific extensions
- `DoubleCombinableArbitraryDelegator` for filter/null injection operations  
- `JqwikDoubleCombinableArbitrary` implementation
- `KotestDoubleCombinableArbitrary` implementation for Kotest integration
- Factory method `CombinableArbitrary.doubles()`

**Key features:**
- Standard numeric constraints: `.positive()`, `.negative()`, `.nonZero()`, `.withRange(double, double)`
- Double-specific precision control: `.withPrecision(int)` method for decimal place specification
- Double-specific value type methods: `.finite()`, `.infinite()`, `.nan()` for handling special floating-point values
- Domain-specific methods:
  - `.percentage()` - generates values 0-100 for percentage representation
  - `.score()` - generates values 0-100 for scoring systems
  - `.normalized()` - generates values 0.0-1.0 for probability and ratio calculations
- **Critical special value injection methods:**
  - `.withSpecialValue(double)` - injects custom edge case values for comprehensive testing coverage
  - `.withStandardSpecialValues()` - automatically injects Double.NaN, Double.MIN_VALUE, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY for robust floating-point edge case testing
- Last-method-wins behavior for constraint precedence (domain-specific methods override previous constraints)
- Full integration with existing filter/map/unique operations

**Usage example:**
```java
Double nonZeroDouble = CombinableArbitrary.doubles().nonZero().combined();
Double precisionDouble = CombinableArbitrary.doubles().withPrecision(3).combined();
Double positiveDouble = CombinableArbitrary.doubles().withRange(1.0, 1000.0).positive().combined();
Double normalizedDouble = CombinableArbitrary.doubles().normalized().combined();
Double percentageDouble = CombinableArbitrary.doubles().percentage().combined();
Double edgeCaseDouble = CombinableArbitrary.doubles().withStandardSpecialValues().combined();
```

## How Has This Been Tested?
Added comprehensive test suite in `DoubleCombinableArbitraryTest`:
- Basic constraint validation (positive, negative, nonZero, finite, infinite, nan)
- Range constraint testing with various boundaries and precision specifications
- Domain-specific constraint testing (percentage, score, normalized)
- Precision control validation for decimal place accuracy
- Special value injection testing for edge case coverage
- Method chaining and last-method-wins precedence verification
- Integration with filter, map, injectNull, unique operations
- Complex constraint combinations and floating-point operation safety
- Domain boundary validation (ensuring normalized values are 0.0-1.0, percentage values are 0-100, etc.)
- Cross-platform compatibility testing with both Jqwik and Kotest implementations

## Is the Document updated?
Documentation will be updated to include DoubleCombinableArbitrary usage examples alongside existing numeric arbitrary types, with special emphasis on precision control, special value handling, and domain-specific constraint methods for common Double use cases in scientific and business applications.